### PR TITLE
Fix nas responsividade dos botoes na tela inicial

### DIFF
--- a/public/css/bulma.css
+++ b/public/css/bulma.css
@@ -262,6 +262,13 @@ table th {
   font-size: 3rem !important;
 }
 
+@media only screen and (max-width: 340px) {
+  .button {
+    font-size: 13px;
+    width: 100%;
+  }
+}
+
 @media screen and (max-width: 768px) {
   .is-size-1-mobile {
     font-size: 3rem !important;


### PR DESCRIPTION
Foi necessario diminuir o tamanho das fontes em modo responsivo para que
o botao nao "quebre" o texto. Apliquei pois julguei ser a soluçao mais rapida.

Ref: #1 
<img width="467" alt="screenshot 2018-10-25 at 18 43 21" src="https://user-images.githubusercontent.com/12386985/47516723-7bdb7f80-d886-11e8-8620-8a05d6320ae9.png">
